### PR TITLE
fix: add chcp 65001 to resolve encoding issue in batch files

### DIFF
--- a/config_manager.bat
+++ b/config_manager.bat
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001>nul 2>&1
 setlocal enabledelayedexpansion
 
 :: pdf2zh 桌面版配置管理器

--- a/debug_start.bat
+++ b/debug_start.bat
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001>nul 2>&1
 setlocal enabledelayedexpansion
 
 :: pdf2zh 桌面版智能启动脚本

--- a/diagnostic.bat
+++ b/diagnostic.bat
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001>nul 2>&1
 setlocal enabledelayedexpansion
 
 :: pdf2zh 桌面版系统诊断工具

--- a/install.bat
+++ b/install.bat
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001>nul 2>&1
 setlocal enabledelayedexpansion
 
 :: pdf2zh 桌面版一键安装脚本

--- a/module_manager.bat
+++ b/module_manager.bat
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001>nul 2>&1
 setlocal enabledelayedexpansion
 
 :: pdf2zh 桌面版模块管理器

--- a/uninstall.bat
+++ b/uninstall.bat
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001>nul 2>&1
 setlocal enabledelayedexpansion
 
 :: pdf2zh 桌面版卸载程序


### PR DESCRIPTION
Added `chcp 65001 >nul 2>&1` at the start of batch files to resolve encoding issues, particularly Chinese garbled text display.

Without `chcp 65001`, Windows Command Prompt uses GBK by default, which can cause garbled characters when the script contains UTF-8 encoded text (such as Chinese). This change ensures the batch files run correctly with UTF-8 encoding silently.